### PR TITLE
Unresolved dependency: bio4j#neo4jdb;0.1.0-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "bio4j" % "neo4jdb" % "0.1.0-SNAPSHOT",
+  "bio4j" % "neo4jdb" % "0.1.0",
   "org.gephi" % "gephi-toolkit" % "0.8.2" classifier("all") intransitive
 )
 


### PR DESCRIPTION
I'm trying to build bio4j examples and came across the above error. I have already done `sbt publish-local` inside `bio4j-neo4jdb` module. But the current version there is: `0.2.0-SNAPSHOT`. What am I missing?

<!---
@huboard:{"order":0.15625,"custom_state":""}
-->
